### PR TITLE
Improve souporcell_pipeline.py speed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+souporcell/target/
+troublet/target/

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ git clone https://github.com/wheaton5/souporcell.git
 ```
 put souporcell directory on your PATH 
 requires samtools, bcftools, htslib, python3, freebayes, vartrix, minimap2 all on your PATH
-python packages tensorflow, pyvcf, pystan, pyfasta, numpy, scipy
+python packages tensorflow, pyvcf, pystan, pyfaidx, numpy, scipy
 
 ## To run through the pipeline script
 ```

--- a/check_modules.py
+++ b/check_modules.py
@@ -6,7 +6,7 @@ import math
 import pystan
 import vcf
 import pysam
-import pyfasta
+import pyfaidx
 import subprocess
 import time
 import os

--- a/consensus.py
+++ b/consensus.py
@@ -10,12 +10,13 @@ parser.add_argument("-r","--ref_matrix",required=True,help="ref matrix file")
 parser.add_argument("-p","--ploidy",required=False, help="ploidy, must be 1 or 2, defaults to 2")
 parser.add_argument("--soup_out",required=True, help="soup output")
 parser.add_argument("--vcf_out",required=True, help="vcf output")
+parser.add_argument("--output_dir", required=True, help = "output directory")
 #parser.add_argument("-d","--doublets",required=True, help="doublet calls")
 parser.add_argument("-v","--vcf",required=True,help="vcf file from which alt and ref matrix were created")
 args = parser.parse_args()
 
 
-dirname = '/'.join(fullpath.split('/')[:-1])
+dirname = args.output_dir
 
 
 def myopen(fname): return open(fname, 'rb') if fname.endswith('.gz') else open(fname)

--- a/consensus.py
+++ b/consensus.py
@@ -15,6 +15,9 @@ parser.add_argument("-v","--vcf",required=True,help="vcf file from which alt and
 args = parser.parse_args()
 
 
+dirname = '/'.join(fullpath.split('/')[:-1])
+
+
 def myopen(fname): return open(fname, 'rb') if fname.endswith('.gz') else open(fname)
 vcftemplate = vcf.Reader(myopen(args.vcf))
 potential_RNAedits = set()
@@ -359,7 +362,8 @@ import gzip
 vcftemplate = vcf.Reader(myopen(args.vcf))
 vcfreader = vcf.Reader(myopen(args.vcf))
 import math
-with open("tempsouporcell.vcf",'w') as geno:
+tmp_vcf = dirname+"/tempsouporcell.vcf"
+with open(tmp_vcf,'w') as geno:
     vcfwriter = vcf.Writer(geno,vcftemplate)
     samples = [str(cluster) for cluster in range(max_cluster+1)]
     vcfwriter.template.samples = samples
@@ -430,7 +434,7 @@ with open("tempsouporcell.vcf",'w') as geno:
                 calls.append(vcf.model._Call(newrec, str(cluster), CallData(gt, ao, ro, truth, err, go, gn)))
             newrec.samples = calls
             vcfwriter.write_record(newrec)
-with open("tempsouporcell.vcf") as tmp:
+with open(tmp_vcf) as tmp:
     with open(args.vcf_out,'w') as out:
         for line in tmp:
             if line.startswith("#"):
@@ -440,4 +444,4 @@ with open("tempsouporcell.vcf") as tmp:
                     out.write(line)
             else:
                 out.write(line)
-subprocess.check_call(["rm","tempsouporcell.vcf"])
+subprocess.check_call(["rm",tmp_vcf])

--- a/renamer.py
+++ b/renamer.py
@@ -50,10 +50,9 @@ with open(args.out,'w') as fastq:
         #            keys_to_remove.append(key)
         #    for key in keys_to_remove:
         #        del recent_umis[key]
-    
         readname = read.qname
         if read.has_tag("CB") and read.get_tag("CB") in cell_barcodes:
-            fastq.write("@"+read.qname+";"+cell_barcode+";"+UMI+"\n")
+            fastq.write("@" + read.qname + " CB:Z:" + cell_barcode + "\tUB:Z:" + UMI + "\n")
             fastq.write(read.seq+"\n")
             fastq.write("+\n")
             fastq.write(read.qual+"\n")

--- a/souporcell.def
+++ b/souporcell.def
@@ -73,7 +73,6 @@ From: conda/miniconda3
 	wget https://github.com/ekg/freebayes/releases/download/v1.3.1/freebayes-v1.3.1
 	mv freebayes-v1.3.1 freebayes
 	chmod 777 freebayes
-        cd ..
         wget https://github.com/10XGenomics/vartrix/releases/download/v1.1.3/vartrix-v1.1.3-x86_64-linux.tar.gz
         tar xzvf vartrix-v1.1.3-x86_64-linux.tar.gz
         rm vartrix-v1.1.3-x86_64-linux.tar.gz

--- a/souporcell.def
+++ b/souporcell.def
@@ -3,7 +3,7 @@ Bootstrap: docker
 From: conda/miniconda3
 
 %environment
-	PATH=/opt/bedtools2/bin:/usr/local/envs/py36/bin:/opt/souporcell:/opt/souporcell/troublet/target/release:/usr/local/condabin:/opt/minimap2-2.7:/root/.cargo/bin:/opt/vartrix-v1.1.3-x86_64-linux/:$PATH
+	PATH=/opt/bedtools2/bin:/usr/local/envs/py36/bin:/opt/souporcell:/opt/souporcell/troublet/target/release:/usr/local/condabin:/opt/minimap2-2.7:/root/.cargo/bin:/opt/vartrix-v1.1.3-x86_64-linux/:/opt:$PATH
 
 %post -c /bin/bash
         apt update
@@ -34,7 +34,6 @@ From: conda/miniconda3
 	rustup default stable
 	yes | apt-get install git
 	cd /opt
-	git clone --recursive git://github.com/ekg/freebayes.git
 	git clone https://github.com/wheaton5/souporcell.git
 	cd souporcell/troublet
 	cargo build --release
@@ -70,10 +69,10 @@ From: conda/miniconda3
         ./configure
         make
         make install
-        cd ..
-        cd freebayes
-        make
-        make install
+	cd /opt
+	wget https://github.com/ekg/freebayes/releases/download/v1.3.1/freebayes-v1.3.1
+	mv freebayes-v1.3.1 freebayes
+	chmod 777 freebayes
         cd ..
         wget https://github.com/10XGenomics/vartrix/releases/download/v1.1.3/vartrix-v1.1.3-x86_64-linux.tar.gz
         tar xzvf vartrix-v1.1.3-x86_64-linux.tar.gz

--- a/souporcell.def
+++ b/souporcell.def
@@ -1,9 +1,9 @@
 Bootstrap: docker
 
-From: continuumio/miniconda3
+From: conda/miniconda3
 
 %environment
-	PATH=/opt/conda/envs/py36/bin:/opt/souporcell:/opt/souporcell/troublet/target/release:/opt/conda/bin:/opt/minimap2-2.7:/root/.cargo/bin:/opt/vartrix-v1.1.3-x86_64-linux/:$PATH
+	PATH=/opt/bedtools2/bin:/usr/local/envs/py36/bin:/opt/souporcell:/opt/souporcell/troublet/target/release:/usr/local/condabin:/opt/minimap2-2.7:/root/.cargo/bin:/opt/vartrix-v1.1.3-x86_64-linux/:$PATH
 
 %post -c /bin/bash
         apt update
@@ -11,30 +11,42 @@ From: continuumio/miniconda3
         yes | apt-get install build-essential
 	yes | apt-get install curl
 	echo blah
-	yes | /opt/conda/bin/conda create -n py36 python=3.6
+	yes | /usr/local/bin/conda create -n py36 python=3.6
 	. /opt/conda/bin/activate py36
         yes | apt-get install libncurses5-dev
         yes | apt-get install zlib1g-dev
         yes | apt-get install libbz2-dev
         yes | apt-get install liblzma-dev
-	curl https://sh.rustup.rs -sSf > blah.sh
-	chmod 777 blah.sh
-	./blah.sh -y
-	rm blah.sh
-	apt-get install git
+	cd /opt
+	wget https://github.com/lh3/minimap2/archive/v2.7.tar.gz
+        tar -xzvf v2.7.tar.gz
+        cd minimap2-2.7
+        make
+	cd ..
+	wget https://github.com/arq5x/bedtools2/releases/download/v2.28.0/bedtools-2.28.0.tar.gz
+	tar -zxvf bedtools-2.28.0.tar.gz
+	cd bedtools2
+	make
+	cd ..
+	CARGO_HOME=/opt/.cargo RUSTUP_HOME=/opt/.cargo bash -c 'curl https://sh.rustup.rs -sSf | sh -s -- -y'
+	source /opt/.cargo/env
+	which cargo
+	rustup default stable
+	yes | apt-get install git
 	cd /opt
 	git clone --recursive git://github.com/ekg/freebayes.git
 	git clone https://github.com/wheaton5/souporcell.git
 	cd souporcell/troublet
-	/root/.cargo/bin/cargo build --release
+	cargo build --release
+	cd /opt/souporcell/souporcell
+	cargo build --release
 	cd /opt
-	/opt/conda/envs/py36/bin/pip install pyvcf
-        /opt/conda/envs/py36/bin/pip install pysam
-        /opt/conda/envs/py36/bin/pip install numpy
-        /opt/conda/envs/py36/bin/pip install scipy
-        /opt/conda/envs/py36/bin/pip install tensorflow
-        /opt/conda/envs/py36/bin/pip install pystan==2.17.1.0
-        /opt/conda/envs/py36/bin/pip install pyfaidx
+	yes | /usr/local/envs/py36/bin/pip install pysam
+	/usr/local/envs/py36/bin/pip install pyvcf
+        /usr/local/envs/py36/bin/pip install numpy
+        /usr/local/envs/py36/bin/pip install scipy
+        /usr/local/envs/py36/bin/pip install pystan==2.17.1.0
+        /usr/local/envs/py36/bin/pip install pyfaidx
         cd /opt
 	wget https://github.com/samtools/htslib/releases/download/1.9/htslib-1.9.tar.bz2
 	tar xvfj htslib-1.9.tar.bz2
@@ -67,8 +79,3 @@ From: continuumio/miniconda3
         tar xzvf vartrix-v1.1.3-x86_64-linux.tar.gz
         rm vartrix-v1.1.3-x86_64-linux.tar.gz
         export PATH=/opt/vartrix-v1.1.3-x86_64-linux:$PATH
-        wget https://github.com/lh3/minimap2/archive/v2.7.tar.gz
-	tar -xzvf v2.7.tar.gz
-	cd minimap2-2.7
-	make
-	yes | /opt/conda/envs/py36/bin/pip install pysam

--- a/souporcell.def
+++ b/souporcell.def
@@ -34,7 +34,7 @@ From: continuumio/miniconda3
         /opt/conda/envs/py36/bin/pip install scipy
         /opt/conda/envs/py36/bin/pip install tensorflow
         /opt/conda/envs/py36/bin/pip install pystan==2.17.1.0
-        /opt/conda/envs/py36/bin/pip install pyfasta
+        /opt/conda/envs/py36/bin/pip install pyfaidx
         cd /opt
 	wget https://github.com/samtools/htslib/releases/download/1.9/htslib-1.9.tar.bz2
 	tar xvfj htslib-1.9.tar.bz2

--- a/souporcell_pipeline.py
+++ b/souporcell_pipeline.py
@@ -451,7 +451,7 @@ def doublets(args, ref_mtx, alt_mtx, cluster_file):
 def consensus(args, ref_mtx, alt_mtx, doublet_file):
     print("running co inference of ambient RNA and cluster genotypes")
     subprocess.check_call(["consensus.py", "-c", doublet_file, "-a", alt_mtx, "-r", ref_mtx, "-p", args.ploidy,
-        "--soup_out", args.out_dir + "/ambient_rna.txt", "--vcf_out", args.out_dir + "/cluster_genotypes.vcf", "--vcf", final_vcf])
+        "--output_dir",args.out_dir,"--soup_out", args.out_dir + "/ambient_rna.txt", "--vcf_out", args.out_dir + "/cluster_genotypes.vcf", "--vcf", final_vcf])
     subprocess.check_call(['touch', args.out_dir + "/consensus.done"])
 
 

--- a/souporcell_pipeline.py
+++ b/souporcell_pipeline.py
@@ -44,8 +44,8 @@ import vcf
 print("importing pysam")
 import pysam
 
-print("importing pyfasta")
-import pyfasta
+print("importing pyfaidx")
+import pyfaidx
 
 print("importing subprocess")
 import subprocess
@@ -105,7 +105,7 @@ if not args.ignore == "True":
     assert float(num_cb_cb) / float(num_read_test) > 0.05, "Less than 25% of first 100000 reads have cell barcodes from barcodes file, is this the correct barcode file? turn on --ignore True to ignore"
 
 print("checking fasta")
-fasta = pyfasta.Fasta(args.fasta, key_fn = lambda key: key.split()[0])
+fasta = pyfaidx.Fasta(args.fasta, key_function = lambda key: key.split()[0])
 
 def make_fastqs(args):
     if not os.path.isfile(args.bam + ".bai"):

--- a/souporcell_pipeline.py
+++ b/souporcell_pipeline.py
@@ -212,7 +212,6 @@ def remap(args, all_fastqs):
     for fq in all_fastqs:
         subprocess.check_call(["rm", fq])
     subprocess.check_call(["rm", fifo])
-    subprocess.check_call(["rm", minimap_index])
 
     return output
 

--- a/souporcell_pipeline.py
+++ b/souporcell_pipeline.py
@@ -2,6 +2,13 @@
 
 import argparse
 
+import logging
+logging.basicConfig(format='%(asctime)s %(message)s', datefmt='%I:%M:%S %p')
+logging.warning('Starting pipeline')
+
+def print(msg):
+    logging.warning(msg)
+
 parser = argparse.ArgumentParser(
     description="single cell RNAseq mixed genotype clustering using sparse mixture model clustering with tensorflow.")
 parser.add_argument("-i", "--bam", required = True, help = "cellranger bam")
@@ -118,157 +125,116 @@ def make_fastqs(args):
     total_reference_length = 0
     for chrom in bam.references:
         total_reference_length += bam.get_reference_length(chrom)
-    step_length = int(math.ceil(total_reference_length / int(args.threads)))
-    regions = []
+    step_length = int(math.ceil(total_reference_length / (2 * int(args.threads))))
+
     region = []
-    region_so_far = 0
-    chrom_so_far = 0
+
     print("creating chunks")
     for chrom in bam.references:
         chrom_length = bam.get_reference_length(chrom)
-        while True:
-            if region_so_far + (chrom_length - chrom_so_far) <= step_length:
-                region.append((chrom, chrom_so_far, chrom_length))
-                region_so_far += chrom_length - chrom_so_far
-                chrom_so_far = 0
-                break
-            else:
-                region.append((chrom, chrom_so_far, step_length - region_so_far))
-                regions.append(region)
-                region = []
-                chrom_so_far += step_length - region_so_far + 1
-                region_so_far = 0
-    if len(region) > 0:
-        regions.append(region)
+        for i in range(math.ceil(chrom_length / step_length)):
+            start = step_length * i
+            end = min(chrom_length, start + step_length)
+            region.append((chrom, start, end))
 
     # for testing, delete this later
     args.threads = int(args.threads)
-    region_fastqs = [[] for x in range(args.threads)]
     all_fastqs = []
     procs = [None for x in range(args.threads)]
     any_running = True
     # run renamer in parallel manner
+
+    current_region = 0
     print("generating fastqs with cell barcodes and umis in readname")
     while any_running:
         any_running = False
-        for (index, region) in enumerate(regions):
-            block = False
+
+        for index in range(len(procs)):
+            slot_open = True
             if procs[index]:
-                block = procs[index].poll() == None
-                if block:
+                returncode = procs[index].poll()
+                slot_open = returncode is not None
+                if not slot_open:
                     any_running = True
                 else:
-                    assert not(procs[index].returncode), "renamer subprocess terminated abnormally with code " + str(procs[index].returncode)
-            if len(region_fastqs[index]) == len(region) - 1:
-                block = True
-            if not block:
-                sub_index = len(region_fastqs[index])
-                chrom = region[sub_index][0]
-                start = region[sub_index][1]
-                end = region[sub_index][2]
-                fq_name = args.out_dir + "/souporcell_fastq_" + str(index) + "_" + str(sub_index) + ".fq"
+                    assert returncode == 0, "renamer subprocess terminated abnormally with code " + str(returncode)
+
+            if slot_open and current_region < len(region):
+                (chrom, start, end) = region[current_region]
+                fq_name = args.out_dir + "/souporcell_fastq_" + str(current_region) + ".fq"
                 p = subprocess.Popen(["renamer.py", "--bam", args.bam, "--barcodes", args.barcodes, "--out", fq_name,
                         "--chrom", chrom, "--start", str(start), "--end", str(end)])
                 all_fastqs.append(fq_name)
                 procs[index] = p
-                region_fastqs[index].append(fq_name)
                 any_running = True
-        time.sleep(0.5)
-    with open(args.out_dir + "/fastqs.done", 'w') as done:
-        for fastqs in region_fastqs:
-            done.write("\t".join(fastqs) + "\n")
-    return((region_fastqs, all_fastqs))
+                current_region += 1
 
-def remap(args, region_fastqs, all_fastqs):
-    print("remapping with minimap2")
+        if not any_running and current_region == len(region):
+            break
+
+        time.sleep(0.5)
+
+    print("done writing fastqs")
+
+    with open(args.out_dir + "/fastqs.done", 'w') as done:
+        for fastq in all_fastqs:
+            done.write(fastq + "\n")
+    return all_fastqs
+
+def remap(args, all_fastqs):
     # run minimap2
-    minimap_tmp_files = []
-    for index in range(args.threads):
-        if index > len(region_fastqs) or len(region_fastqs[index]) == 0:
-            continue
-        output = args.out_dir + "/souporcell_minimap_tmp_" + str(index) + ".sam"
-        minimap_tmp_files.append(output)
-        with open(args.out_dir + "/tmp.fq", 'w') as tmpfq:
-            subprocess.check_call(['cat'] + region_fastqs[index], stdout = tmpfq)
-        with open(output, 'w') as samfile:
-            with open(args.out_dir + "/minimap.err",'w') as minierr:
-                minierr.write("mapping\n")
-                #subprocess.check_call(["hisat2", "-p", str(args.threads), "-q", args.out_dir + "/tmp.fq", "-x", 
-                #args.fasta[:-3],
-                #"-S", output], stderr =minierr)
-                cmd = ["minimap2", "-ax", "splice", "-t", str(args.threads), "-G50k", "-k", "21",
-                    "-w", "11", "--sr", "-A2", "-B8", "-O12,32", "-E2,1", "-r200", "-p.5", "-N20", "-f1000,5000",
-                    "-n2", "-m20", "-s40", "-g2000", "-2K50m", "--secondary=no", args.fasta, args.out_dir + "/tmp.fq"]
-                minierr.write(" ".join(cmd)+"\n")
-                subprocess.check_call(["minimap2", "-ax", "splice", "-t", str(args.threads), "-G50k", "-k", "21", 
-                    "-w", "11", "--sr", "-A2", "-B8", "-O12,32", "-E2,1", "-r200", "-p.5", "-N20", "-f1000,5000",
-                    "-n2", "-m20", "-s40", "-g2000", "-2K50m", "--secondary=no", args.fasta, args.out_dir + "/tmp.fq"], 
-                    stdout = samfile, stderr = minierr)
-        subprocess.check_call(['rm', args.out_dir + "/tmp.fq"])
+
+    print("indexing genome for minimap2")
+    minimap_index = args.out_dir + "/minimap_index.mmi"
+    subprocess.check_call(["minimap2", "-ax", "splice", "-sr", "-k", "21", "-w", "11", "-d", minimap_index, args.fasta])
+
+    #merged_fq_fn = args.out_dir + "/merged.fastq"
+    #with open(merged_fq_fn, "w") as merged_fq:
+    #    subprocess.check_call(["cat"] + all_fastqs, stdout = merged_fq)
+
+    fifo = args.out_dir + "/fasta.fifo"
+    subprocess.check_call(["mkfifo", fifo])
+
+    # Stream data to fifo
+    fifo_proc = subprocess.Popen("cat " + " ".join(all_fastqs) + " > " + fifo, shell=True)
+
+
+    samtools_threads = 3
+
+    print("remapping with minimap2")
+    with open(args.out_dir + "/minimap.err",'w') as minierr:
+        minierr.write("mapping\n")
+        cmd = ["minimap2", "-ax", "splice", "-t", str(args.threads), "-G50k", "-k", "21",
+               "-w", "11", "--sr", "-A2", "-B8", "-O12,32", "-E2,1", "-r200", "-p.5", "-N20", "-f1000,5000",
+               "-y", "-n2", "-m20", "-s40", "-g2000", "-2K50m", "--secondary=no", minimap_index, fifo]
+        minierr.write(" ".join(cmd)+"\n")
+        minimap_ps = subprocess.Popen(cmd, stdout = subprocess.PIPE, stderr = minierr)
+        output = args.out_dir + "/souporcell_minimap.bam"
+        subprocess.check_call(["samtools", "view", "-b", "-@", str(samtools_threads), "-o", output, "-"], stdin=minimap_ps.stdout, stderr = minierr)
 
     with open(args.out_dir + '/remapping.done', 'w') as done:
-        for fn in minimap_tmp_files:
-            done.write(fn + "\n")
-    print("cleaning up tmp fastqs")
-    # clean up tmp fastqs
+            done.write(output + "\n")
+
+    # clean up tmp files
     for fq in all_fastqs:
         subprocess.check_call(["rm", fq])
-    return(minimap_tmp_files)
+    subprocess.check_call(["rm", fifo])
+    subprocess.check_call(["rm", minimap_index])
 
-def retag(args, minimap_tmp_files):
-    print("repopulating cell barcode and UMI tags")
-    # run retagger
-    procs = []
-    retag_files = []
-    for index in range(args.threads):
-        if index > len(minimap_tmp_files) -1:
-            continue
-        outfile = args.out_dir + "/souporcell_retag_tmp_" + str(index) + ".bam"
-        retag_files.append(outfile)
-        p = subprocess.Popen(["retag.py", "--sam", minimap_tmp_files[index], "--out", outfile])
-        procs.append(p)
-    for p in procs: # wait for processes to finish
-        p.wait()
-        assert not(p.returncode), "retag subprocess ended abnormally with code " + str(p.returncode)
+    return output
 
+def sort(args, minimap_tmp_file):
 
-    print("sorting retagged bam files")
-    # sort retagged files
-    sort_jobs = []
-    filenames = []
-    with open(args.out_dir + "/retag.err", 'w') as retagerr:
-        for index in range(args.threads):
-            if index > len(retag_files) - 1:
-                continue
-            filename = args.out_dir + "/souporcell_retag_sorted_tmp_" + str(index) + ".bam"
-            filenames.append(filename)
-            p = subprocess.Popen(["samtools", "sort", retag_files[index], '-o', filename], stderr = retagerr)
-            sort_jobs.append(p)
-        
-    # wait for jobs to finish
-    for job in sort_jobs:
-        job.wait()
-        assert not(job.returncode), "samtools sort ended abnormally with code " + str(job.returncode)
-
-    #clean up unsorted bams
-    for bam in retag_files:
-        subprocess.check_call(["rm", bam])
-
-    print("merging sorted bams")
+    print("sorting bam")
     final_bam = args.out_dir + "/souporcell_minimap_tagged_sorted.bam"
-    subprocess.check_call(["samtools", "merge", final_bam] + filenames)
 
-    subprocess.check_call(["samtools", "index", final_bam])
-    
-    print("cleaning up tmp samfiles")
-    # clean up tmp samfiles
-    for samfile in minimap_tmp_files:
-        subprocess.check_call(["rm", samfile])
+    subprocess.check_call(["samtools", "sort", "-@", str(args.threads), "--write-index", "-o", final_bam,  minimap_tmp_file])
 
     # clean up tmp bams
-    for filename in filenames:
-        subprocess.check_call(['rm', filename])
+    subprocess.check_call(['rm', minimap_tmp_file])
     subprocess.check_call(["touch", args.out_dir + "/retagging.done"])
+
+    return final_bam
 
 def freebayes(args, bam, fasta):
     total_reference_length = 0
@@ -463,26 +429,20 @@ else:
     subprocess.check_call(["mkdir", args.out_dir])
 if not args.skip_remap:
     if not os.path.exists(args.out_dir + "/fastqs.done"):
-        (region_fastqs, all_fastqs) = make_fastqs(args)
+        all_fastqs = make_fastqs(args)
     else:
         all_fastqs = []
-        region_fastqs = []
         with open(args.out_dir + "/fastqs.done") as fastqs:
             for line in fastqs:
-                toks = line.strip().split("\t")
-                region_fastqs.append(toks)
-                for tok in toks:
-                    all_fastqs.append(tok)
+                all_fastqs.append(line.strip())
     if not os.path.exists(args.out_dir + "/remapping.done"):
-        minimap_tmp_files = remap(args, region_fastqs, all_fastqs)
+        minimap_tmp_file = remap(args, all_fastqs)
     else:
-        minimap_tmp_files = []
-        with open(args.out_dir + "/remapping.done") as bams:
-            for line in bams:
-                minimap_tmp_files.append(line.strip())
-    if not os.path.exists(args.out_dir + "/retagging.done"):
-        retag(args, minimap_tmp_files)
-    bam = args.out_dir + "/souporcell_minimap_tagged_sorted.bam" 
+        with open(args.out_dir + "/remapping.done") as bam:
+            minimap_tmp_file = bam.readline().strip()
+    if not os.path.exists(args.out_dir + "/sorting.done"):
+        sort(args, minimap_tmp_file)
+    bam = args.out_dir + "/souporcell_minimap_tagged_sorted.bam"
 else:
     bam = args.bam
 if not os.path.exists(args.out_dir + "/variants.done"):


### PR DESCRIPTION
@wheaton5 -- FYI.  I will merge in your latest changes & send you a PR.

- have minimap2 automatically generate tags using the `-y` flag. Requires a tiny tweak to the fastq headers being fed to minimap2
- Run a single instance of `minimap2` by using`mkfifo` to cat together all the FASTQs.
- Generate a single BAM file by piping from `minimap2` to `samtools view`
- Use `samtools sort -@ <args.threads> --write-index` to sort and index the BAM file in one shot.

Brings the wall time for args.threads = 16 from 9hrs down to 4.5hrs on a 30k cell test dataset.
